### PR TITLE
Correct case of OpenSkill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "description": "This is a laravel 5 package for the server and client side of datatables at http://datatables.net/",
+    "description": "This is a Laravel 5 package for the server and client side of DataTables (http://datatables.net/)",
     "keywords" : ["laravel","datatables", "ajax", "jquery"],
     "license": "MIT",
     "homepage": "http://github.com/OpenSkill/Datatable",

--- a/src/OpenSkill/Datatable/Columns/ColumnBuilder.php
+++ b/src/OpenSkill/Datatable/Columns/ColumnBuilder.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSKill\Datatable\Columns;
+namespace OpenSkill\Datatable\Columns;
 
 
-use OpenSKill\Datatable\Composers\DTDataComposer;
+use OpenSkill\Datatable\Composers\DTDataComposer;
 
 class ColumnBuilder extends ColumnConfigurationBuilder
 {

--- a/src/OpenSkill/Datatable/Columns/ColumnConfiguration.php
+++ b/src/OpenSkill/Datatable/Columns/ColumnConfiguration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSKill\Datatable\Columns;
+namespace OpenSkill\Datatable\Columns;
 
 /**
  * Class ColumnConfiguration

--- a/src/OpenSkill/Datatable/Composers/DTDataComposer.php
+++ b/src/OpenSkill/Datatable/Composers/DTDataComposer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSKill\Datatable\Composers;
+namespace OpenSkill\Datatable\Composers;
 
-use OpenSKill\Datatable\Columns\ColumnConfiguration;
-use OpenSKill\Datatable\Columns\ColumnConfigurationBuilder;
-use OpenSKill\Datatable\Providers\DTProvider;
+use OpenSkill\Datatable\Columns\ColumnConfiguration;
+use OpenSkill\Datatable\Columns\ColumnConfigurationBuilder;
+use OpenSkill\Datatable\Providers\DTProvider;
 
 /**
  * Class DTDataComposer

--- a/src/OpenSkill/Datatable/Composers/DTViewComposer.php
+++ b/src/OpenSkill/Datatable/Composers/DTViewComposer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSKill\Datatable\Composers;
+namespace OpenSkill\Datatable\Composers;
 
 
 class DTViewComposer

--- a/src/OpenSkill/Datatable/Datatable.php
+++ b/src/OpenSkill/Datatable/Datatable.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OpenSKill\Datatable;
+namespace OpenSkill\Datatable;
 
-use OpenSKill\Datatable\Providers\DTProvider;
-use OpenSKill\Datatable\Composers\DTDataComposer;
+use OpenSkill\Datatable\Providers\DTProvider;
+use OpenSkill\Datatable\Composers\DTDataComposer;
 use Illuminate\Http\Request;
 
 /**

--- a/src/OpenSkill/Datatable/DatatableServiceProvider.php
+++ b/src/OpenSkill/Datatable/DatatableServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSKill\Datatable;
+namespace OpenSkill\Datatable;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/src/OpenSkill/Datatable/Facades/DatatableFacade.php
+++ b/src/OpenSkill/Datatable/Facades/DatatableFacade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSKill\Datatable\Facades;
+namespace OpenSkill\Datatable\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/OpenSkill/Datatable/Interfaces/DTData.php
+++ b/src/OpenSkill/Datatable/Interfaces/DTData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSKill\Datatable\Interfaces;
+namespace OpenSkill\Datatable\Interfaces;
 
 
 class DTData

--- a/src/OpenSkill/Datatable/Interfaces/DTQueryConfiguration.php
+++ b/src/OpenSkill/Datatable/Interfaces/DTQueryConfiguration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSKill\Datatable\Interfaces;
+namespace OpenSkill\Datatable\Interfaces;
 
 /**
  * Class DTQueryConfiguration

--- a/src/OpenSkill/Datatable/Providers/CollectionProvider.php
+++ b/src/OpenSkill/Datatable/Providers/CollectionProvider.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace OpenSKill\Datatable\Providers;
+namespace OpenSkill\Datatable\Providers;
 
 use Illuminate\Support\Collection;
-use OpenSKill\Datatable\Columns\ColumnConfiguration;
-use OpenSKill\Datatable\Interfaces\DTData;
-use OpenSKill\Datatable\Interfaces\DTQueryConfiguration;
+use OpenSkill\Datatable\Columns\ColumnConfiguration;
+use OpenSkill\Datatable\Interfaces\DTData;
+use OpenSkill\Datatable\Interfaces\DTQueryConfiguration;
 
 /**
  * Class CollectionProvider
- * @package OpenSKill\Datatable\Providers
+ * @package OpenSkill\Datatable\Providers
  *
  * Provider that is able to provide data based on a initial passed collection.
  */

--- a/src/OpenSkill/Datatable/Providers/DTProvider.php
+++ b/src/OpenSkill/Datatable/Providers/DTProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenSKill\Datatable\Providers;
+namespace OpenSkill\Datatable\Providers;
 
-use OpenSKill\Datatable\Columns\ColumnConfiguration;
-use OpenSKill\Datatable\Interfaces\DTData;
-use OpenSKill\Datatable\Interfaces\DTQueryConfiguration;
+use OpenSkill\Datatable\Columns\ColumnConfiguration;
+use OpenSkill\Datatable\Interfaces\DTData;
+use OpenSkill\Datatable\Interfaces\DTQueryConfiguration;
 
 /**
  * Interface DatatableProvider

--- a/src/OpenSkill/Datatable/Utils/DTVersion.php
+++ b/src/OpenSkill/Datatable/Utils/DTVersion.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenSKill\Datatable\Utils;
+namespace OpenSkill\Datatable\Utils;
 
 
 /**


### PR DESCRIPTION
Based on the organisation name, the case of the namespace in the classes is incorrect.
