### PR TITLE
Setup proper routing for table ajax

### DIFF
--- a/src/views/datatable110.blade.php
+++ b/src/views/datatable110.blade.php
@@ -4,7 +4,7 @@
         oTable = jQuery('#{{ $id }}').DataTable({
             "processing": true,
             "serverSide": true,
-            "ajax": "/",
+            "ajax": "{{ isset($options['route']) ? $options['route'] : '/' }}",
             "columns": [
                 @foreach($columns as $name => $label)
                 { 'data': '{{ $label }}' },

--- a/src/views/datatable110.blade.php
+++ b/src/views/datatable110.blade.php
@@ -7,7 +7,7 @@
             "ajax": "{{ isset($options['route']) ? $options['route'] : '/' }}",
             "columns": [
                 @foreach($columns as $name => $label)
-                { 'data': '{{ $label }}' },
+                { 'data': '{{ $name }}' },
                 @endforeach
             ]
         });

--- a/src/views/datatable19.blade.php
+++ b/src/views/datatable19.blade.php
@@ -4,7 +4,7 @@
         oTable = jQuery('#{{ $id }}').dataTable({
             "bProcessing": true,
             "bServerSide": true,
-            "sAjaxSource": "/",
+            "sAjaxSource": "{{ isset($options['route']) ? $options['route'] : '/' }}",
             "aoColumns": [
                 @foreach($columns as $name => $label)
                 { 'mData': '{{ $label }}' },

--- a/src/views/datatable19.blade.php
+++ b/src/views/datatable19.blade.php
@@ -7,7 +7,7 @@
             "sAjaxSource": "{{ isset($options['route']) ? $options['route'] : '/' }}",
             "aoColumns": [
                 @foreach($columns as $name => $label)
-                { 'mData': '{{ $label }}' },
+                { 'mData': '{{ $name }}' },
                 @endforeach
             ]
         });


### PR DESCRIPTION
I noticed when I was starting out with this package that the ajax source for datatable is always the root directory and there is no method to override this without editing the default view.

Made an update here that updates the view files allowing you to use `$table->option('route', URL_HERE)` to define the ajax source.

Not sure if this is the best way to do it since from what I see of this package so far it assumes that the ajax source is from the same route as the view source.

EDIT:

Noticed that the columns were based on the value of the array rather then the index, when the value is the label. This leads to errors when overriding table headers.
