### PR TITLE
Add the endpoint() option.

### DIFF
--- a/src/OpenSkill/Datatable/Views/DatatableView.php
+++ b/src/OpenSkill/Datatable/Views/DatatableView.php
@@ -46,6 +46,9 @@ class DatatableView
     /** @var Repository The repository responsible for the config value resolution */
     private $configRepository;
 
+    /** @var string the URL for the endpoint */
+    private $endpointURL = '/';
+
     /**
      * DatatableView constructor, will take a view as a string if a custom one should be used. will also take the
      * column configurations to provide out of the box headers for the view.
@@ -121,6 +124,17 @@ class DatatableView
     }
 
     /**
+     * Sets the endpoint URL that will be passed to templates when rendering html & scripts.
+     * @param $endpoint_url
+     * @return $this
+     */
+    public function endpoint($endpoint_url)
+    {
+        $this->endpointURL = $endpoint_url;
+        return $this;
+    }
+
+    /**
      * Will set the columns for the view
      * @param string $columnName The name of the column
      * @param string $label The label for this column
@@ -158,7 +172,8 @@ class DatatableView
             ->make($this->tableView, [
                 'columns' => $this->columns,
                 'showHeaders' => $this->printHeaders,
-                'id' => $this->tableId
+                'id' => $this->tableId,
+                'endpoint' => $this->endpointURL,
             ])
             ->render();
     }
@@ -179,6 +194,7 @@ class DatatableView
                 'columns' => $this->columns,
                 'options' => $this->scriptOptions,
                 'callbacks' => $this->scriptCallbacks,
+                'endpoint' => $this->endpointURL,
             ])
             ->render();
     }

--- a/src/views/datatable110.blade.php
+++ b/src/views/datatable110.blade.php
@@ -4,7 +4,7 @@
         oTable = jQuery('#{{ $id }}').DataTable({
             "processing": true,
             "serverSide": true,
-            "ajax": "{{ isset($options['route']) ? $options['route'] : '/' }}",
+            "ajax": "{{ $endpoint }}",
             "columns": [
                 @foreach($columns as $name => $label)
                 { 'data': '{{ $name }}' },

--- a/src/views/datatable19.blade.php
+++ b/src/views/datatable19.blade.php
@@ -4,7 +4,7 @@
         oTable = jQuery('#{{ $id }}').dataTable({
             "bProcessing": true,
             "bServerSide": true,
-            "sAjaxSource": "{{ isset($options['route']) ? $options['route'] : '/' }}",
+            "sAjaxSource": "{{ $endpoint }}",
             "aoColumns": [
                 @foreach($columns as $name => $label)
                 { 'mData': '{{ $name }}' },

--- a/tests/OpenSkill/Datatable/Views/DatatableViewTest.php
+++ b/tests/OpenSkill/Datatable/Views/DatatableViewTest.php
@@ -96,6 +96,7 @@ class DatatableViewTest extends \PHPUnit_Framework_TestCase
                     'columns' => ['id' => 'id'],
                     'showHeaders' => false,
                     'id' => 123,
+                    'endpoint' => '/'
                 ]
             ])
             ->times(1)
@@ -119,6 +120,7 @@ class DatatableViewTest extends \PHPUnit_Framework_TestCase
                         'fooBar1' => ['fooBar']
                     ],
                     'callbacks' => [],
+                    'endpoint' => '/'
                 ]
             ])
             ->times(1)
@@ -143,6 +145,7 @@ class DatatableViewTest extends \PHPUnit_Framework_TestCase
                         'fooBar' => 'fooBar',
                         'fooBar1' => ['fooBar']
                     ],
+                    'endpoint' => '/'
                 ]
             ])
             ->times(1)
@@ -163,7 +166,8 @@ class DatatableViewTest extends \PHPUnit_Framework_TestCase
                     'columns' => ['id' => 'id'],
                     'showHeaders' => true,
                     'id' => 'fooBar',
-                ]
+                    'endpoint' => '/'
+                ],
             ])
             ->times(1)
             ->andReturn($this->view);
@@ -185,7 +189,8 @@ class DatatableViewTest extends \PHPUnit_Framework_TestCase
                     ],
                     'showHeaders' => false,
                     'id' => 'fooBar',
-                ]
+                    'endpoint' => '/'
+                ],
             ])
             ->times(1)
             ->andReturn($this->view);
@@ -201,6 +206,7 @@ class DatatableViewTest extends \PHPUnit_Framework_TestCase
                     ],
                     'options' => [],
                     'callbacks' => [],
+                    'endpoint' => '/'
                 ]
             ])
             ->times(1)
@@ -209,6 +215,40 @@ class DatatableViewTest extends \PHPUnit_Framework_TestCase
         $this->dtv2->columns('fooBar', 'fooBarLabel');
         $this->dtv2->columns('fooBar2');
 
+        $this->dtv2->html();
+    }
+
+    public function testEndpoint()
+    {
+        $this->viewFactory->shouldReceive('make')
+            ->withArgs([
+                'fooTable',
+                [
+                    'columns' => ['id' => 'id'],
+                    'showHeaders' => false,
+                    'id' => 'fooBar',
+                    'endpoint' => '/test/endpoint/gets/set'
+                ],
+            ])
+            ->times(1)
+            ->andReturn($this->view);
+
+        $this->viewFactory->shouldReceive('make')
+            ->withArgs([
+                'fooScript',
+                [
+                    'id' => 'fooBar',
+                    'columns' => ['id' => 'id'],
+                    'options' => [],
+                    'callbacks' => [],
+                    'endpoint' => '/test/endpoint/gets/set'
+                ]
+            ])
+            ->times(1)
+            ->andReturn($this->view);
+
+
+        $this->dtv2->endpoint('/test/endpoint/gets/set');
         $this->dtv2->html();
     }
 


### PR DESCRIPTION
Instead of having to set an option on the view, you can now just use ->endpoint to specify the URL.

``` php
{{
    $datatable
        ->headers() // tell the table to render the header in the table
        ->columns('id', '#') // show # in the header instead of 'id'
        ->columns('name', 'Full name') // show 'Full name' in the header instead of 'name'
        ->endpoint(route('asd.asd'))
        // render just the table
        ->table()
}}
```

Originally, I was planning on having the endpoint() function call route directly (or use `app->make(...)`) but then I realised that this would stop you from using external urls and routes without a name. Also, `endpoint(route(...))` is a little bit more expressive.

This means that you can also use `endpoint(secure(...))`, which is a syntax I am falling in love with :)
