### PR TITLE
Ensure that Datatable19Version is selected when needed.

### DIFF
--- a/src/OpenSkill/Datatable/DatatableServiceProvider.php
+++ b/src/OpenSkill/Datatable/DatatableServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ServiceProvider;
 use OpenSkill\Datatable\Versions\Datatable110Version;
 use OpenSkill\Datatable\Versions\Datatable19Version;
 use OpenSkill\Datatable\Versions\VersionEngine;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class DatatableServiceProvider extends ServiceProvider

--- a/src/OpenSkill/Datatable/Versions/VersionEngine.php
+++ b/src/OpenSkill/Datatable/Versions/VersionEngine.php
@@ -25,7 +25,7 @@ class VersionEngine
     public function __construct(array $versions)
     {
         foreach ($versions as $v) {
-            if ($v->canParseRequest() || is_null($this->version)) {
+            if ($v->canParseRequest()) {
                 $this->version = $v;
                 break;
             }

--- a/tests/OpenSkill/Datatable/Versions/VersionEngineTest.php
+++ b/tests/OpenSkill/Datatable/Versions/VersionEngineTest.php
@@ -4,9 +4,11 @@ namespace packages\OpenSkill\Datatable\tests\OpenSkill\Datatable\Versions;
 
 
 use Mockery;
+use OpenSkill\Datatable\Versions\Datatable110Version;
 use OpenSkill\Datatable\Versions\Datatable19Version;
 use OpenSkill\Datatable\Versions\Version;
 use OpenSkill\Datatable\Versions\VersionEngine;
+use Symfony\Component\HttpFoundation\Request;
 
 class VersionEngineTest extends \PHPUnit_Framework_TestCase
 {
@@ -38,5 +40,43 @@ class VersionEngineTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($version, $versionEngine->getVersion());
     }
 
+    public function testGivesDatatable19Version()
+    {
+        $query = new Request([
+            'sEcho' => '6',
+            'iColumns' => '2',
+            'sColumns' => '',
+            'iDisplayStart' => '0',
+            'iDisplayLength' => '10',
+            'mDataProp_0' => 'id',
+            'mDataProp_1' => 'name',
+            'sSearch' => '',
+            'bRegex' => 'false',
+            'sSearch_0' => '',
+            'bRegex_0' => 'false',
+            'bSearchable_0' => 'true',
+            'sSearch_1' => '',
+            'bRegex_1' => 'false',
+            'bSearchable_1' => 'true',
+            'iSortCol_0' => '0',
+            'sSortDir_0' => 'asc',
+            'iSortingCols' => '1',
+            'bSortable_0' => 'true',
+            'bSortable_1' => 'true',
+            '_' => '1456903066843'
+        ]);
+
+        $requestStack = Mockery::mock('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack->shouldReceive('getCurrentRequest')->andReturn($query);
+
+        $dt = new Datatable19Version($requestStack);
+        $dt2 = new Datatable110Version($requestStack);
+
+        $versionEngine = new VersionEngine([$dt2, $dt]);
+
+        $this->assertTrue($versionEngine->hasVersion());
+        $this->assertTrue($versionEngine->getVersion()->canParseRequest());
+        $this->assertSame($dt, $versionEngine->getVersion());
+    }
 
 }


### PR DESCRIPTION
Write a test for, and fix an issue where Datatable110Version would always be selected, even if Datatable19Version was wanted.

Solves (one of) the issues I was having in #26 where I needed to edit `DatatableServiceProvider` in order to get data out of a datatable.
